### PR TITLE
Use canvas.width / height instead

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,28 +21,28 @@ var x = 50;
 var y = 50;
 
 function canvasDraw() {
-  if(x > canvas.clientWidth+20) {
+  if(x > canvas.width + 20) {
     x = 0;  
   }
 
-  if(y > canvas.clientHeight+20) {
+  if(y > canvas.height + 20) {
     y = 0;  
   }  
 
   if(x < -20) {
-    x = canvas.clientWidth;  
+    x = canvas.width;
   }
 
   if(y < -20) {
-    y = canvas.clientHeight;  
+    y = canvas.height;
   }
 
   ctx.fillStyle = "black";
-  ctx.fillRect(0,0,canvas.clientWidth,canvas.clientHeight);
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = "#f00";
   
   ctx.beginPath();
-  ctx.arc(x,y,20,0,degToRad(360), true);
+  ctx.arc(x, y, 20, 0, degToRad(360), true);
   ctx.fill();
 }
 


### PR DESCRIPTION
Getting `clientWidth` / `clientHeight` require result from layout, which is much more expensive than getting `width` / `height` from the canvas element.